### PR TITLE
OAM-36: add sonar analysis

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -1,0 +1,44 @@
+name: SonarCloud angola-reports Pipeline
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'zulu'
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build with Docker Compose
+        run: |
+          curl -o .env -L https://raw.githubusercontent.com/OpenLMIS/openlmis-ref-distro/master/settings-sample.env
+          docker-compose -f docker-compose.builder.yml run builder
+          sudo chown -R $(whoami) ./
+          cp ./build/reports/jacoco/test/jacocoTestReport.xml report.xml
+          rm -rf ./build
+      - name: SonarCloud Scan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonarqube --info

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 plugins {
     id "org.flywaydb.flyway" version "4.0"
-    id "org.sonarqube" version "2.6.1"
+    id "org.sonarqube" version "3.3"
     id "com.moowork.node" version "0.12"
 }
 

--- a/codeAnalysis.gradle
+++ b/codeAnalysis.gradle
@@ -33,17 +33,10 @@ configure(checkApiIsRaml) {
 //Usage: gradle sonarqube
 sonarqube {
     properties {
-        property "sonar.projectName", "Angola Reports Service"
-        property "sonar.projectKey", "org.sonarqube:angola-reports"
-        property "sonar.projectVersion", version
-        property "sonar.host.url", "http://sonar.openlmis.org"
-        property "sonar.java.coveragePlugin", "jacoco"
-        //Tells SonarQube where the unit tests execution reports are
-        property "sonar.junit.reportsPath", "build/test-results/test"
-        //Tells SonarQube where the unit tests code coverage report is
-        property "sonar.jacoco.reportPath", "build/jacoco/test.exec"
-        //Tells SonarQube where the integration tests code coverage report is
-        property "sonar.jacoco.itReportPath", "build/jacoco/integrationTest.exec"
-    properties["sonar.tests"] += sourceSets.integrationTest.java
+        property "sonar.projectKey", "OpenLMIS-Angola_angola-reports"
+        property "sonar.organization", "openlmis-angola"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.java.source", "17"
+        property "sonar.coverage.jacoco.xmlReportPaths", "./report.xml"
     }
 }

--- a/dependency.gradle
+++ b/dependency.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile "org.flywaydb:flyway-core:4.0.3"
     compile "org.javers:javers-spring-boot-starter-sql:2.8.1"
     compile "org.postgresql:postgresql:42.2.20"
-    compile "org.projectlombok:lombok:1.16.8"
+    compile "org.projectlombok:lombok:1.18.22"
     compile "org.webjars:swagger-ui:2.2.6"
 
     compile "org.apache.poi:poi:3.16"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 
   "scripts":
   {
-    "runApiSpecConverter": "api-spec-converter --from raml --to swagger_2 /build/resources/main/api-definition-swagger.yaml > /build/resources/main/static/reports/docs/api-definition.json",
-    "runApiHtmlConverter": "raml2html --input /build/resources/main/api-definition-raml.yaml --output /build/resources/main/api-definition.html"
+    "runApiSpecConverter": "api-spec-converter --from raml --to swagger_2 ./build/resources/main/api-definition-swagger.yaml > ./build/resources/main/static/reports/docs/api-definition.json",
+    "runApiHtmlConverter": "raml2html --input ./build/resources/main/api-definition-raml.yaml --output ./build/resources/main/api-definition.html"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 
   "scripts":
   {
-    "runApiSpecConverter": "api-spec-converter --from raml --to swagger_2 /app/build/resources/main/api-definition-swagger.yaml > /app/build/resources/main/static/reports/docs/api-definition.json",
-    "runApiHtmlConverter": "raml2html --input /app/build/resources/main/api-definition-raml.yaml --output /app/build/resources/main/api-definition.html"
+    "runApiSpecConverter": "api-spec-converter --from raml --to swagger_2 /build/resources/main/api-definition-swagger.yaml > /build/resources/main/static/reports/docs/api-definition.json",
+    "runApiHtmlConverter": "raml2html --input /build/resources/main/api-definition-raml.yaml --output /build/resources/main/api-definition.html"
   }
 }

--- a/tests.gradle
+++ b/tests.gradle
@@ -23,7 +23,7 @@ jacocoTestReport {
     group = "reporting"
     description = "Generate Jacoco coverage reports after running tests."
     reports {
-        xml.enabled false
+        xml.enabled true
         html.enabled true
         csv.enabled false
     }


### PR DESCRIPTION
[OAM-36](https://openlmis.atlassian.net/browse/OAM-36)

Changes:
- Enable generation of _jacocoTestReport.xml_.
- Create a GH workflow to scan angola-reports repository on push/PR.

[OAM-36]: https://openlmis.atlassian.net/browse/OAM-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ